### PR TITLE
Fix scheduled inspection navigation

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -91,6 +91,10 @@ const Dashboard = ({ user, onLogout, onNewMaintenance }) => {
     navigate(`/maintenance?edit=${inspectionId}`)
   }
 
+  const handleStartInspection = (inspectionId) => {
+    navigate(`/maintenance?inspectionId=${inspectionId}`)
+  }
+
   const handleTestInspectionCreated = () => {
     // Refresh dashboard data to show the new inspection
     loadDashboardData()
@@ -409,10 +413,10 @@ const Dashboard = ({ user, onLogout, onNewMaintenance }) => {
                             </Button>
                           )}
                           {item.status === 'scheduled' && (
-                            <Button 
-                              size="sm" 
+                            <Button
+                              size="sm"
                               variant="default"
-                              onClick={() => handleEditInspection(item.id)}
+                              onClick={() => handleStartInspection(item.id)}
                               className="h-8 text-xs"
                             >
                               <Clock className="h-3 w-3 mr-1" />
@@ -462,10 +466,10 @@ const Dashboard = ({ user, onLogout, onNewMaintenance }) => {
                             </Button>
                           )}
                           {item.status === 'scheduled' && (
-                            <Button 
-                              size="sm" 
+                            <Button
+                              size="sm"
                               variant="default"
-                              onClick={() => handleEditInspection(item.id)}
+                              onClick={() => handleStartInspection(item.id)}
                             >
                               <Clock className="h-4 w-4 mr-1" />
                               Start Inspection

--- a/src/components/MaintenanceHandler.jsx
+++ b/src/components/MaintenanceHandler.jsx
@@ -11,15 +11,6 @@ const MaintenanceHandler = ({ maintenanceSession, scannedRobot, user, onSessionU
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 
-  useEffect(() => {
-    const inspectionId = searchParams.get('edit')
-    
-    if (inspectionId && !maintenanceSession) {
-      // Load scheduled inspection from API or localStorage
-      loadScheduledInspection(inspectionId)
-    }
-  }, [searchParams, maintenanceSession, loadScheduledInspection])
-
   const loadScheduledInspection = useCallback(async (inspectionId) => {
     try {
       setLoading(true)
@@ -100,6 +91,16 @@ const MaintenanceHandler = ({ maintenanceSession, scannedRobot, user, onSessionU
       setLoading(false)
     }
   }, [user, navigate])
+
+  useEffect(() => {
+    const inspectionId =
+      searchParams.get('inspectionId') || searchParams.get('edit')
+
+    if (inspectionId && !maintenanceSession) {
+      // Load scheduled inspection from API or localStorage
+      loadScheduledInspection(inspectionId)
+    }
+  }, [searchParams, maintenanceSession, loadScheduledInspection])
 
   const handleSessionUpdate = (updatedSession) => {
     setCurrentSession(updatedSession)


### PR DESCRIPTION
## Summary
- start inspections with `inspectionId` query param
- read `inspectionId` in `MaintenanceHandler`
- move scheduled inspection loader above `useEffect`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6880ada27c508323b3f46a7b6031ca4c