### PR TITLE
Add configurable PDF service URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Example environment variables for Field Maintenance App
+# Copy this file to `.env` and adjust values as needed.
+
+# Base URL for PDF generation service
+VITE_PDF_SERVICE_URL=https://your-pdf-service-url.com/api/reports

--- a/DEPLOYMENT_GUIDE.md
+++ b/DEPLOYMENT_GUIDE.md
@@ -30,7 +30,7 @@ Deploy the contents of the `dist/` folder to your hosting service:
 ### 4. Environment Configuration
 Ensure the following environment variables are set:
 - Firebase configuration is already included in the code
-- PDF service URL may need updating in `src/services/pdfService.js`
+- `VITE_PDF_SERVICE_URL` - base URL of the PDF service used by `pdfService.js`
 
 ## PDF Backend Deployment
 

--- a/src/services/pdfService.js
+++ b/src/services/pdfService.js
@@ -1,7 +1,11 @@
 // PDF Service
 // Handles PDF generation requests to the backend service
 
-const PDF_SERVICE_URL = 'https://5000-idd93o1prlynxk19ggzn6-afbdef95.manusvm.computer/api/reports';
+// Base URL for the PDF service
+// Can be overridden via the `VITE_PDF_SERVICE_URL` environment variable
+const PDF_SERVICE_URL =
+  import.meta.env.VITE_PDF_SERVICE_URL ||
+  'https://5000-idd93o1prlynxk19ggzn6-afbdef95.manusvm.computer/api/reports';
 
 class PDFService {
   constructor() {


### PR DESCRIPTION
## Summary
- make PDF service base URL configurable via environment variable
- document new env var in deployment guide
- provide `.env.example` with the variable

## Testing
- `pnpm lint` *(fails: react-refresh/only-export-components errors)*
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_6880f31ad81c8323923b19ab66a8f9e6